### PR TITLE
fix: use context Provider typo

### DIFF
--- a/examples/context/reference-caveats-solution.js
+++ b/examples/context/reference-caveats-solution.js
@@ -10,9 +10,9 @@ class App extends React.Component {
   render() {
     // highlight-range{2}
     return (
-      <Provider value={this.state.value}>
+      <MyContext.Provider value={this.state.value}>
         <Toolbar />
-      </Provider>
+      </MyContext.Provider>
     );
   }
 }


### PR DESCRIPTION
Salute for your awesome work, the PR is for the purpose to fix the typo of component, modified `<Provider>` to `<MyContext.Provider>`

The official reactjs.org docs of context part, found [here](https://reactjs.org/docs/context.html#caveats), source code found [here](https://github.com/reactjs/reactjs.org/blob/master/examples/context/reference-caveats-solution.js).



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
